### PR TITLE
Repair windows batch files

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,3 +18,4 @@ Costantino Giuliodori <costantino.giuliodori@gmail.com>
 - Heikki Ylönen <heikki74@gmail.com>
 - Jonah Kagan <jonahkagan@gmail.com>
 - Kyle Finley <kylefinley@gmail.com>
+- Matias Lahti <gigaton@gmail.com>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,4 +29,4 @@ Kyle Finley <kylefinley@gmail.com>
 - Heikki Ylönen <heikki74@gmail.com>
 - Jonah Kagan <jonahkagan@gmail.com>
 - Gulin Serge <gulin.serge@gmail.com>
-
+- Matias Lahti <gigaton@gmail.com>

--- a/scripts/compile-html.bat
+++ b/scripts/compile-html.bat
@@ -1,5 +1,5 @@
-node node_modules/.bin/jade app/index.jade --pretty --out app/assets/
-node node_modules/.bin/jade app/partials/ --pretty --out app/assets/partials/
+node_modules/.bin/jade app/index.jade --pretty --out app/assets/
+node_modules/.bin/jade app/partials/ --pretty --out app/assets/partials/
 
 del app/index.jade 
 rd /s /q app/partials/

--- a/scripts/compile-tests.bat
+++ b/scripts/compile-tests.bat
@@ -1,1 +1,1 @@
-node node_modules\.bin\coffee -cw -b test
+node_modules\.bin\coffee -cw -b test

--- a/scripts/development.bat
+++ b/scripts/development.bat
@@ -1,2 +1,2 @@
 rd /s /q _public
-node node_modules/.bin/brunch watch
+node_modules/.bin/brunch watch

--- a/scripts/production.bat
+++ b/scripts/production.bat
@@ -1,2 +1,2 @@
 rd /s /q _public
-node node_modules/.bin/brunch build -m
+node_modules/.bin/brunch build -m

--- a/scripts/server.bat
+++ b/scripts/server.bat
@@ -1,2 +1,2 @@
 rd /s /q _public
-node node_modules/.bin/brunch watch --server
+node_modules/.bin/brunch watch --server

--- a/scripts/test-e2e.bat
+++ b/scripts/test-e2e.bat
@@ -1,1 +1,1 @@
-node node_modules/.bin/testacular start test/testacular-e2e.conf.js
+node_modules/.bin/testacular start test/testacular-e2e.conf.js

--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -1,1 +1,1 @@
-node node_modules/.bin/testacular start test/testacular.conf.js
+node_modules/.bin/testacular start test/testacular.conf.js


### PR DESCRIPTION
Hi, 
 seems like npm creates .cmd files in .bin that call the actual javascript files, similar to the shell scripts it creates there. 

Previously, you called the javascript files directly, that got executed correctly on *nix (and cygwin, I'd imagine) due to the hashbang which doesn't exist on Windows and Serge created the batch files to address this - eg. to call 'node node_modules/brunch/bin/brunch'. 

When changing them to use node_modules/.bin, calling the node executable stuck around and thus it tried to run the generated shellscript with node, resulting in errors when running the batch files on Windows. 

The extra call to the node binary is now removed and this pull should fix the batch files to run correctly on the first run for those of us that have to use Windows.. 

Thanks for the skeleton, though, I'm liking it!
- Matias
