### PR TITLE
Housecleaning package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "clean-css-brunch": ">= 1.0 < 1.5",
 
     "jade-brunch": ">= 1.3 < 1.5",
-    "static-jade-brunch": "1.4.5"
+    "static-jade-brunch": ">= 1.4 < 1.5"
   },
   "devDependencies": {
     "coffee-script": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "clean-css-brunch": ">= 1.0 < 1.5",
 
     "jade-brunch": ">= 1.3 < 1.5",
-    "static-jade-brunch": ">= 1.4 < 1.5"
+    "static-jade-brunch": ">= 1.4.0 <= 1.4.5 || >= 1.4.8 < 1.5"
   },
   "devDependencies": {
     "coffee-script": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
       "name": "Gulin Serge",
       "email": "gulin.serge@gmail.com"
     },
+    {
       "name": "Heikki Ylönen",
       "email": "heikki74@gmail.com"
     },


### PR DESCRIPTION
Hi, 
  just a bit of housecleaning in package.json. Added a missing brace that breaks npm install and make sure the buggy versions (1.4.6-1.4.7 as far as I can tell) of static-jade-brunch are not allowed. 1.4.8 of static-jade-brunch reverted the changes made in 1.4.7 to 1.4.5 and it seems to be recompiling index.jade correctly.

-Matias
