### PR TITLE
fixed jquery version in brunch config

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -14,7 +14,7 @@ exports.config =
       order:
         before: [
           'vendor/scripts/console-helper.js'
-          'vendor/scripts/jquery-1.8.1.js'
+          'vendor/scripts/jquery-1.8.3.js'
           'vendor/scripts/angular/angular.js'
           'vendor/scripts/angular/angular-resource.js'
           'vendor/scripts/angular/angular-cookies.js'


### PR DESCRIPTION
File was updated to latest version, but config ref was not. Caused errors when bootstrap js modules were being included in vendor.js before jQuery was.
