### PR TITLE
Fix Bower Error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "bower-stylesheet-brunch": "*",
     "bower-javascript-brunch": "*",
     "bower-asserts-brunch": "*",
-    "bower": "~0.7.0",
+    "bower": "~0.8.5",
 
     "jade-angularjs-brunch": ">= 0.0.5",
 


### PR DESCRIPTION
Bower was throwing this error when `bower install` was called:

```
path.js:360
        throw new TypeError('Arguments to path.join must be strings');
```

They had the same problem in `yeoman`, which was fixed here: https://github.com/yeoman/generator/commit/c8188b4cb3c63db6298394328dfffda4dada247f
