### PR TITLE
updated bower to work with less-theme

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "console-polyfill": "~0.1.0",
     "jquery": "~2.0.3",
     "bootstrap-less": "~2.3.2",
-    "bootstrap-less-themes": "git://github.com/angular-brunch/bootstrap-less-themes.git",
+    "bootstrap-less-themes": "https://github.com/angular-brunch/bootstrap-less-themes.git",
     "angular-bootstrap": "~0.4.0",
     "angular": "1.0.7",
     "angular-sanitize": "1.0.7",


### PR DESCRIPTION
bower is giving error (git exit with 128 code) for git based link, so changed it to https based link. It is working for that.
