### PR TITLE
Added a regex to ignore files which start with an underscore.

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -2,7 +2,7 @@ exports.config =
   # See docs at http://brunch.readthedocs.org/en/latest/config.html.
   conventions:
     assets:  /^app\/assets\//
-    ignored: /^(bower_components\/bootstrap-less(-themes)?|app\/styles\/overrides)/
+    ignored: /^(bower_components\/bootstrap-less(-themes)?|app\/styles\/overrides|(.*?\/)?[_]\w*)/
   modules:
     definition: false
     wrapper: false
@@ -23,7 +23,7 @@ exports.config =
         ]
 
     templates:
-      joinTo: 
+      joinTo:
         'js/dontUseMe' : /^app/ # dirty hack for Jade compiling.
 
   plugins:


### PR DESCRIPTION
The first `(.*?\/)` of the regex check for anyhing before the file, and then anything with an underscore and non-whitespace (`[_]\w*`) is included in the result.

``` regex
(.*?\/)?[_]\w*)
```

This was required because processors like sass-brunch were failing on compilations.
