### PR TITLE
Documentation corrected to enable using HTML templates instead of Jade

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ HTML run the command:
 ```
 ./scripts/compile-html.sh
 ```
+
+Open "app/app.coffee" and remove the dependency on 'partials' on the module App.
+
+
 All Jade file will be compiled to HTML and be placed in the `app/assets` directory.
 Additionally, the `*.jade` files will be removed from the project. Any changes
 that you make to the `app/assets/**/*.html` files will now appear in the browser.


### PR DESCRIPTION
Instructions on using plain HTML templates instead of Jade templates were incomplete. In order to use HTML templates one needs to remove dependency on "partials" for the module App in "app/app.coffee". Otherwise one gets an error and the browser is not updated on changing the HTML templates.
